### PR TITLE
Fix initial value in chat recall

### DIFF
--- a/src/content/features/chat-recall/chat-recall.feature.ts
+++ b/src/content/features/chat-recall/chat-recall.feature.ts
@@ -24,7 +24,7 @@ export class ChatRecallFeature extends TypoFeature {
       if(this._historyIndex === undefined) {
         if(event.key === "ArrowUp"){
           this._historyIndex = this._history.length - 1;
-          element.value = this._history[this._historyIndex];
+          element.value = this._history[this._historyIndex] ?? "";
         }
       }
 


### PR DESCRIPTION
This fixes a bug where pressing up-arrow before sending any messages in chat fills chat input with 'undefined'