### PR TITLE
Userscript version doesn't show log in with discord in the user info feature

### DIFF
--- a/src/runtime/page/page-runtime.ts
+++ b/src/runtime/page/page-runtime.ts
@@ -31,7 +31,7 @@ export default class PageRuntime implements TypoRuntime {
   }
 
   async getSetting(key: string): Promise<string | null> {
-    return (await this._db).get("settings", key);
+    return await (await this._db).get("settings", key) ?? null;
   }
 
   async writeSetting(key: string, value: string | null): Promise<void> {
@@ -39,8 +39,7 @@ export default class PageRuntime implements TypoRuntime {
   }
 
   async getToken(): Promise<string | null> {
-    const tokenPromise = (await this._db).get("token", "token");
-    return (await tokenPromise) ?? null;
+    return await (await this._db).get("token", "token") ?? null;
   }
 
   async setToken(token: string | null): Promise<void> {


### PR DESCRIPTION
Fixes https://github.com/toobeeh/skribbltypo/issues/429

idb returned `undefined` if the token hadn't been set as anything yet so it happened on fresh install, but it was handled as being only a string or null. This makes the value `null` if it's `undefined` so they're treated the same way