### PR TITLE
Fix chat clear message limiting

### DIFF
--- a/src/app/features/chat-clear/chat-clear.feature.ts
+++ b/src/app/features/chat-clear/chat-clear.feature.ts
@@ -56,7 +56,7 @@ export class ChatClearFeature extends TypoFeature {
               /* else limit reached, delete last and add new */
               else {
                 acc[0].remove();
-                acc.splice(1);
+                acc.shift();
                 acc.push(message.element);
               }
 


### PR DESCRIPTION
Fixes chat clear message limiting as far as I could test. 

technical: the issue was that `array.splice(1)` removes all elements after index 1 instead of removing the first element, the correct operation was `shift`