### PR TITLE
Fix color picker bug in firefox

### DIFF
--- a/src/app/services/drawing/drawing.service.ts
+++ b/src/app/services/drawing/drawing.service.ts
@@ -313,7 +313,11 @@ export class DrawingService {
    */
   public setColor(color: number, secondary = false) {
     this._logger.debug("Setting color", color);
-    document.dispatchEvent(new CustomEvent("setColor", {detail: {code: color, secondary}}));
+    let detail = { code: color, secondary };
+    if (typeof window.cloneInto !== "undefined") {
+      detail = window.cloneInto(detail, window);
+    }
+    document.dispatchEvent(new CustomEvent("setColor", { detail }));
   }
 
   /**

--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -1,5 +1,13 @@
+export {};
+
 declare module "*?raw"
 {
   const content: string;
   export default content;
+}
+
+declare global {
+  interface Window {
+    cloneInto?: <T>(obj: T, scope: Window) => T;
+  }
 }


### PR DESCRIPTION
on firefox, gecko doesn't allow sharing some objects between extensions and the main page. other CustomEvents sent from the extension might need this treatment in the future as well

it also adds a method declaration to the global declarations, if more firefox-specific support happens it should probably be replaced with @types/firefox-webext-browser

fixes #532 